### PR TITLE
feat: v2 commp cid

### DIFF
--- a/.github/workflows/go-check.yml
+++ b/.github/workflows/go-check.yml
@@ -1,0 +1,74 @@
+# File managed by web3-bot. DO NOT EDIT.
+# See https://github.com/protocol/.github/ for details.
+
+on:
+  pull_request:
+  push:
+    branches: ["main","release"]
+name: Go Checks
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event_name == 'push' && github.sha || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  unit:
+    runs-on: ubuntu-latest
+    name: All
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+      - id: config
+        uses: protocol/.github/.github/actions/read-config@master
+      - uses: actions/setup-go@v3
+        with:
+          go-version: 1.20.x
+      - name: Run repo-specific setup
+        uses: ./.github/actions/go-check-setup
+        if: hashFiles('./.github/actions/go-check-setup') != ''
+      - name: Install staticcheck
+        run: go install honnef.co/go/tools/cmd/staticcheck@4970552d932f48b71485287748246cf3237cebdf # 2023.1 (v0.4.0)
+      - name: Check that go.mod is tidy
+        uses: protocol/multiple-go-modules@v1.2
+        with:
+          run: |
+            go mod tidy
+            if [[ -n $(git ls-files --other --exclude-standard --directory -- go.sum) ]]; then
+              echo "go.sum was added by go mod tidy"
+              exit 1
+            fi
+            git diff --exit-code -- go.sum go.mod
+      - name: gofmt
+        if: success() || failure() # run this step even if the previous one failed
+        run: |
+          out=$(gofmt -s -l .)
+          if [[ -n "$out" ]]; then
+            echo $out | awk '{print "::error file=" $0 ",line=0,col=0::File is not gofmt-ed."}'
+            exit 1
+          fi
+      - name: go vet
+        if: success() || failure() # run this step even if the previous one failed
+        uses: protocol/multiple-go-modules@v1.2
+        with:
+          run: go vet ./...
+      - name: staticcheck
+        if: success() || failure() # run this step even if the previous one failed
+        uses: protocol/multiple-go-modules@v1.2
+        with:
+          run: |
+            set -o pipefail
+            staticcheck ./... | sed -e 's@\(.*\)\.go@./\1.go@g'
+      - name: go generate
+        uses: protocol/multiple-go-modules@v1.2
+        if: (success() || failure()) && fromJSON(steps.config.outputs.json).gogenerate == true
+        with:
+          run: |
+            git clean -fd # make sure there aren't untracked files / directories
+            go generate -x ./...
+            # check if go generate modified or added any files
+            if ! $(git add . && git diff-index HEAD --exit-code --quiet); then
+              echo "go generated caused changes to the repository:"
+              git status --short
+              exit 1
+            fi

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -1,0 +1,98 @@
+# File managed by web3-bot. DO NOT EDIT.
+# See https://github.com/protocol/.github/ for details.
+
+on:
+  pull_request:
+  push:
+    branches: ["main","release"]
+name: Go Test
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event_name == 'push' && github.sha || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  unit:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ "ubuntu", "windows", "macos" ]
+        go: ["1.19.x","1.20.x"]
+    env:
+      GOTESTFLAGS: -cover -coverprofile=module-coverage.txt -coverpkg=./...
+      GO386FLAGS: ''
+      GORACEFLAGS: ''
+    runs-on: ${{ fromJSON(vars[format('UCI_GO_TEST_RUNNER_{0}', matrix.os)] || format('"{0}-latest"', matrix.os)) }}
+    name: ${{ matrix.os }} (go ${{ matrix.go }})
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+      - id: config
+        uses: protocol/.github/.github/actions/read-config@master
+      - if: toJSON(fromJSON(steps.config.outputs.json).shuffle) != 'false'
+        run: |
+          echo "GOTESTFLAGS=-shuffle=on $GOTESTFLAGS" >> $GITHUB_ENV
+          echo "GO386FLAGS=-shuffle=on $GO386FLAGS" >> $GITHUB_ENV
+          echo "GORACEFLAGS=-shuffle=on $GORACEFLAGS" >> $GITHUB_ENV
+      - if: toJSON(fromJSON(steps.config.outputs.json).verbose) != 'false'
+        run: |
+          echo "GOTESTFLAGS=-v $GOTESTFLAGS" >> $GITHUB_ENV
+          echo "GO386FLAGS=-v $GO386FLAGS" >> $GITHUB_ENV
+          echo "GORACEFLAGS=-v $GORACEFLAGS" >> $GITHUB_ENV
+      - uses: actions/setup-go@v3
+        with:
+          go-version: ${{ matrix.go }}
+      - name: Go information
+        run: |
+          go version
+          go env
+      - name: Use msys2 on windows
+        if: matrix.os == 'windows'
+        shell: bash
+        # The executable for msys2 is also called bash.cmd
+        #   https://github.com/actions/virtual-environments/blob/main/images/win/Windows2019-Readme.md#shells
+        # If we prepend its location to the PATH
+        #   subsequent 'shell: bash' steps will use msys2 instead of gitbash
+        run: echo "C:/msys64/usr/bin" >> $GITHUB_PATH
+      - name: Run repo-specific setup
+        uses: ./.github/actions/go-test-setup
+        if: hashFiles('./.github/actions/go-test-setup') != ''
+      - name: Run tests
+        if: contains(fromJSON(steps.config.outputs.json).skipOSes, matrix.os) == false
+        uses: protocol/multiple-go-modules@v1.2
+        env:
+          GOFLAGS: ${{ format('{0} {1}', env.GOTESTFLAGS, env.GOFLAGS) }}
+        with:
+          run: go test ./...
+      - name: Run tests (32 bit)
+        # can't run 32 bit tests on OSX.
+        if: matrix.os != 'macos' &&
+          fromJSON(steps.config.outputs.json).skip32bit != true &&
+          contains(fromJSON(steps.config.outputs.json).skipOSes, matrix.os) == false
+        uses: protocol/multiple-go-modules@v1.2
+        env:
+          GOARCH: 386
+          GOFLAGS: ${{ format('{0} {1}', env.GO386FLAGS, env.GOFLAGS) }}
+        with:
+          run: |
+            export "PATH=$PATH_386:$PATH"
+            go test ./...
+      - name: Run tests with race detector
+        # speed things up. Windows and OSX VMs are slow
+        if: matrix.os == 'ubuntu' &&
+          contains(fromJSON(steps.config.outputs.json).skipOSes, matrix.os) == false
+        uses: protocol/multiple-go-modules@v1.2
+        env:
+          GOFLAGS: ${{ format('{0} {1}', env.GORACEFLAGS, env.GOFLAGS) }}
+        with:
+          run: go test -race ./...
+      - name: Collect coverage files
+        id: coverages
+        shell: bash
+        run: echo "files=$(find . -type f -name 'module-coverage.txt' | tr -s '\n' ',' | sed 's/,$//')" >> $GITHUB_OUTPUT
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70 # v3.1.1
+        with:
+          files: ${{ steps.coverages.outputs.files }}
+          env_vars: OS=${{ matrix.os }}, GO=${{ matrix.go }}

--- a/commcid.go
+++ b/commcid.go
@@ -5,6 +5,7 @@ package commcid
 import (
 	"errors"
 	"fmt"
+	"math/bits"
 
 	"github.com/ipfs/go-cid"
 	"github.com/multiformats/go-multihash"
@@ -24,6 +25,8 @@ const FILCODEC_UNDEFINED = FilMultiCodec(0)
 // FILMULTIHASH_UNDEFINED is a signifier for "no multihash etermined"
 const FILMULTIHASH_UNDEFINED = FilMultiHash(0)
 
+const FR32_SHA256_TRUNC254_PADDED_BINARY_TREE_CODE = 0x1011
+
 var (
 	// ErrIncorrectCodec means the codec for a CID is a block format that does not match
 	// a commitment hash
@@ -37,6 +40,7 @@ var (
 // by adding:
 // - the given filecoin codec type
 // - the given filecoin hash type
+// Deprecated: Use the alternatives like ReplicaCommitmentV1ToCID, DataCommitmentV1ToCID or DataCommitmentV1ToCID
 func CommitmentToCID(mc FilMultiCodec, mh FilMultiHash, commX []byte) (cid.Cid, error) {
 	if err := validateFilecoinCidSegments(mc, mh, commX); err != nil {
 		return cid.Undef, err
@@ -57,6 +61,8 @@ func CommitmentToCID(mc FilMultiCodec, mh FilMultiHash, commX []byte) (cid.Cid, 
 // CIDToCommitment extracts the raw commitment bytes, the FilMultiCodec and
 // FilMultiHash from a CID, after validating that the codec and hash type are
 // consistent
+//
+// Deprecated: Use the alternatives like CIDToReplicaCommitmentV1, CIDToDataCommitmentV1 or PieceMhCIDToDataCommitmentV1
 func CIDToCommitment(c cid.Cid) (FilMultiCodec, FilMultiHash, []byte, error) {
 	decoded, err := multihash.Decode([]byte(c.Hash()))
 	if err != nil {
@@ -76,12 +82,82 @@ func CIDToCommitment(c cid.Cid) (FilMultiCodec, FilMultiHash, []byte, error) {
 // by adding:
 // - codec: cid.FilCommitmentUnsealed
 // - hash type: multihash.SHA2_256_TRUNC254_PADDED
+//
+// Deprecated: This function should be avoided when possible and DataCommitmentV1ToPieceMhCID preferred
 func DataCommitmentV1ToCID(commD []byte) (cid.Cid, error) {
 	return CommitmentToCID(cid.FilCommitmentUnsealed, multihash.SHA2_256_TRUNC254_PADDED, commD)
 }
 
+// Fr32PaddedSizeToV1TreeHeight calculates the height of the piece tree given data that's been FR32 padded. Because
+// pieces are only defined on binary trees if the size is not a power of 2 it will be rounded up to the next one under
+// the assumption that the rest of the tree will be padded out (e.g. with zeros)
+func Fr32PaddedSizeToV1TreeHeight(size uint64) uint8 {
+	if size <= 32 {
+		return 0
+	}
+
+	// Calculate the floor of log2(size)
+	b := 63 - bits.LeadingZeros64(size)
+	// Leaf size is 32 == 2^5
+	b -= 5
+
+	// Check if the size is a power of 2 and if not then add one since the tree will need to be padded out
+	if 32<<b < size {
+		b += 1
+	}
+	return uint8(b)
+}
+
+// UnpaddedSizeToV1TreeHeight calculates the height of the piece tree given the data that's meant to be encoded in the
+// tree before any FR32 padding is applied. Because pieces are only defined on binary trees of FR32 encoded data if the
+// size is not a power of 2 after the FR32 padding is applied it will be rounded up to the next one under the assumption
+// that the rest of the tree will be padded out (e.g. with zeros)
+func UnpaddedSizeToV1TreeHeight(size uint64) uint8 {
+	paddedSize := size * 128 / 127
+	if paddedSize*127 != size*128 {
+		paddedSize += 1
+	}
+
+	return Fr32PaddedSizeToV1TreeHeight(paddedSize)
+}
+
+// DataCommitmentV1ToPieceMhCID converts a raw data commitment and the height of the commitment tree
+// (i.e. log_2(padded data size in bytes) - 5, because 2^5 is 32 bytes which is the leaf node size) to a CID
+// by adding:
+// - codec: cid.Raw
+// - hash type: multihash.SHA2_256_TRUNC254_PADDED_BINARY_TREE
+//
+// The helpers UnpaddedSizeToV1TreeHeight and Fr32PaddedSizeToV1TreeHeight may help in computing tree height
+func DataCommitmentV1ToPieceMhCID(commD []byte, height uint8) (cid.Cid, error) {
+	if len(commD) != 32 {
+		return cid.Undef, fmt.Errorf("commitments must be 32 bytes long")
+	}
+
+	if height < 2 {
+		return cid.Undef, fmt.Errorf("tree height must be at least 2, but was %d", height)
+	}
+
+	mh := FR32_SHA256_TRUNC254_PADDED_BINARY_TREE_CODE
+	digestSize := len(commD) + 1
+
+	mhBuf := make(
+		[]byte,
+		varint.UvarintSize(uint64(mh))+varint.UvarintSize(uint64(digestSize))+digestSize,
+	)
+
+	pos := varint.PutUvarint(mhBuf, uint64(mh))
+	pos += varint.PutUvarint(mhBuf[pos:], uint64(digestSize))
+	mhBuf[pos] = height
+	pos++
+	copy(mhBuf[pos:], commD)
+
+	return cid.NewCidV1(uint64(cid.Raw), mhBuf), nil
+}
+
 // CIDToDataCommitmentV1 extracts the raw data commitment from a CID
 // after checking for the correct codec and hash types.
+//
+// Deprecated: This function should be avoided when possible and PieceMhCIDToDataCommitmentV1 preferred
 func CIDToDataCommitmentV1(c cid.Cid) ([]byte, error) {
 	codec, _, commD, err := CIDToCommitment(c)
 	if err != nil {
@@ -91,6 +167,31 @@ func CIDToDataCommitmentV1(c cid.Cid) ([]byte, error) {
 		return nil, ErrIncorrectCodec
 	}
 	return commD, nil
+}
+
+// PieceMhCIDToDataCommitmentV1 extracts the raw data commitment and tree height from the CID
+func PieceMhCIDToDataCommitmentV1(c cid.Cid) ([]byte, uint8, error) {
+	decoded, err := multihash.Decode(c.Hash())
+	if err != nil {
+		return nil, 0, xerrors.Errorf("Error decoding data commitment hash: %w", err)
+	}
+
+	if decoded.Code != FR32_SHA256_TRUNC254_PADDED_BINARY_TREE_CODE {
+		return nil, 0, ErrIncorrectHash
+	}
+
+	if decoded.Length != 33 {
+		return nil, 0, xerrors.Errorf("expected multihash digest to be 33 bytes, but was %d bytes", decoded.Length)
+	}
+
+	height := decoded.Digest[0]
+
+	if height < 2 {
+		return nil, 0, fmt.Errorf("tree height must be at least 2, but was %d", height)
+	}
+
+	commitmentHash := decoded.Digest[1:]
+	return commitmentHash, height, nil
 }
 
 // ReplicaCommitmentV1ToCID converts a raw data commitment to a CID
@@ -138,12 +239,44 @@ func validateFilecoinCidSegments(mc FilMultiCodec, mh FilMultiHash, commX []byte
 	return nil
 }
 
+// ConvertDataCommitmentV1V1CIDtoPieceMhCID takes a v1 piece CID and the CommP tree height and produces a
+// piece multihash CID
+//
+// The helpers UnpaddedSizeToV1TreeHeight and Fr32PaddedSizeToV1TreeHeight may help in computing tree height
+func ConvertDataCommitmentV1V1CIDtoPieceMhCID(v1PieceCid cid.Cid, treeHeight uint8) (cid.Cid, error) {
+	hashDigest, err := CIDToDataCommitmentV1(v1PieceCid)
+	if err != nil {
+		return cid.Undef, xerrors.Errorf("Error decoding piece CID v1: %w", err)
+	}
+
+	return DataCommitmentV1ToPieceMhCID(hashDigest, treeHeight)
+}
+
+// ConvertDataCommitmentV1PieceMhCIDToV1CID takes a piece multihash CID and produces a v1 piece CID along with the
+// tree height of the CommP tree
+func ConvertDataCommitmentV1PieceMhCIDToV1CID(pieceMhCid cid.Cid) (cid.Cid, uint8, error) {
+	digest, height, err := PieceMhCIDToDataCommitmentV1(pieceMhCid)
+	if err != nil {
+		return cid.Undef, 0, xerrors.Errorf("Error decoding data piece CID v2: %w", err)
+	}
+
+	c, err := DataCommitmentV1ToCID(digest)
+	if err != nil {
+		return cid.Undef, 0, xerrors.Errorf("Could not create piece CID v1: %w", err)
+	}
+	return c, height, nil
+}
+
 // PieceCommitmentV1ToCID converts a commP to a CID
 // -- it is just a helper function that is equivalent to
 // DataCommitmentV1ToCID.
+//
+// Deprecated: This function should be avoided when possible and DataCommitmentV1ToPieceMhCID preferred
 var PieceCommitmentV1ToCID = DataCommitmentV1ToCID
 
 // CIDToPieceCommitmentV1 converts a CID to a commP
 // -- it is just a helper function that is equivalent to
 // CIDToDataCommitmentV1.
+//
+// Deprecated: This function should be avoided when possible and PieceMhCIDToDataCommitmentV1 preferred
 var CIDToPieceCommitmentV1 = CIDToDataCommitmentV1

--- a/commcid_test.go
+++ b/commcid_test.go
@@ -2,7 +2,7 @@ package commcid_test
 
 import (
 	"bytes"
-	"math/rand"
+	"crypto/rand"
 	"testing"
 
 	commcid "github.com/filecoin-project/go-fil-commcid"

--- a/commcid_test.go
+++ b/commcid_test.go
@@ -3,6 +3,7 @@ package commcid_test
 import (
 	"bytes"
 	"crypto/rand"
+	"fmt"
 	"testing"
 
 	commcid "github.com/filecoin-project/go-fil-commcid"
@@ -216,6 +217,189 @@ func TestCIDToPieceCommitment(t *testing.T) {
 		require.EqualError(t, err, commcid.ErrIncorrectHash.Error())
 		require.Nil(t, decoded)
 	})
+}
+
+func TestPieceCommitmentToPieceMhCID(t *testing.T) {
+	randBytes := make([]byte, 33)
+	_, err := rand.Read(randBytes)
+	require.NoError(t, err)
+	randHeight := randBytes[0]
+	randBytes = randBytes[1:]
+
+	c, err := commcid.DataCommitmentV1ToPieceMhCID(randBytes, randHeight)
+	require.NoError(t, err)
+
+	require.Equal(t, c.Prefix().Codec, uint64(cid.Raw))
+	mh := c.Hash()
+	decoded, err := multihash.Decode([]byte(mh))
+	require.NoError(t, err)
+	require.Equal(t, decoded.Code, uint64(commcid.FR32_SHA256_TRUNC254_PADDED_BINARY_TREE_CODE))
+	require.Equal(t, decoded.Length, len(randBytes)+1)
+	require.True(t, decoded.Digest[0] == randHeight)
+	require.True(t, bytes.Equal(decoded.Digest[1:], randBytes))
+
+	_, err = commcid.DataCommitmentV1ToPieceMhCID(randBytes[1:], randHeight)
+	require.Regexp(t, "^commitments must be 32 bytes long", err.Error())
+}
+
+func TestPieceMhCIDToPieceCommitment(t *testing.T) {
+	randBytes := make([]byte, 33)
+	_, err := rand.Read(randBytes)
+	require.NoError(t, err)
+	// Height must be at least 7
+	randBytes[0] = (randBytes[0] % (255 - 7)) + 7
+
+	t.Run("with correct hash format", func(t *testing.T) {
+		hash := testMultiHash(commcid.FR32_SHA256_TRUNC254_PADDED_BINARY_TREE_CODE, randBytes, 0)
+
+		t.Run("decodes raw commitment hash when correct cid format", func(t *testing.T) {
+			c := cid.NewCidV1(cid.Raw, hash)
+			decoded, height, err := commcid.PieceMhCIDToDataCommitmentV1(c)
+			require.NoError(t, err)
+			require.True(t, height == randBytes[0])
+			require.True(t, bytes.Equal(decoded, randBytes[1:]))
+		})
+
+		t.Run("don't error on non-Raw CID format", func(t *testing.T) {
+			c := cid.NewCidV1(cid.DagCBOR, hash)
+			decoded, height, err := commcid.PieceMhCIDToDataCommitmentV1(c)
+			require.NoError(t, err)
+			require.True(t, height == randBytes[0])
+			require.True(t, bytes.Equal(decoded, randBytes[1:]))
+		})
+	})
+
+	t.Run("error on incorrectly formatted hash", func(t *testing.T) {
+		hash := testMultiHash(commcid.FR32_SHA256_TRUNC254_PADDED_BINARY_TREE_CODE, randBytes, 5)
+		c := cid.NewCidV1(cid.Raw, hash)
+		decoded, _, err := commcid.PieceMhCIDToDataCommitmentV1(c)
+		require.Error(t, err)
+		require.Regexp(t, "^Error decoding data commitment hash:", err.Error())
+		require.Nil(t, decoded)
+	})
+	t.Run("error on wrong hash type", func(t *testing.T) {
+		encoded, err := multihash.Encode(randBytes, multihash.SHA2_256)
+		require.NoError(t, err)
+		c := cid.NewCidV1(cid.Raw, multihash.Multihash(encoded))
+		decoded, _, err := commcid.PieceMhCIDToDataCommitmentV1(c)
+		require.EqualError(t, err, commcid.ErrIncorrectHash.Error())
+		require.Nil(t, decoded)
+	})
+}
+
+func TestTreeHeight(t *testing.T) {
+	// Add test fixtures
+	noFr32PaddingTests := map[string]struct {
+		size   uint64
+		height uint8
+	}{
+		"127OfEach0-1-2-3":          {127 * 4, 4},
+		"512-bytes-should-pad-over": {512, 5},
+		"0":                         {0, 0},
+		"1":                         {1, 0},
+		"31":                        {31, 0},
+		"32":                        {32, 1},
+		"127":                       {127, 2},
+		"32GiB":                     {32 << 30, 31},
+		"64GiB":                     {64 << 30, 32},
+	}
+
+	for name, tc := range noFr32PaddingTests {
+		t.Run(fmt.Sprintf("non-fr32-padding %s", name), func(t *testing.T) {
+			require.Equal(t, tc.height, commcid.UnpaddedSizeToV1TreeHeight(tc.size))
+		})
+	}
+
+	// Add test fixtures
+	fr32PaddingTests := map[string]struct {
+		size   uint64
+		height uint8
+	}{
+		"127OfEach0-1-2-3":              {127 * 4, 4},
+		"512-bytes-should-not-pad-over": {512, 4},
+		"0":                             {0, 0},
+		"1":                             {1, 0},
+		"31":                            {31, 0},
+		"32":                            {32, 0},
+		"127":                           {127, 2},
+		"128":                           {128, 2},
+		"129":                           {129, 3},
+		"32GiB":                         {32 << 30, 30},
+		"64GiB":                         {64 << 30, 31},
+	}
+
+	for name, tc := range fr32PaddingTests {
+		t.Run(fmt.Sprintf("with-fr32-padding %s", name), func(t *testing.T) {
+			require.Equal(t, tc.height, commcid.Fr32PaddedSizeToV1TreeHeight(tc.size))
+		})
+	}
+}
+
+func TestPieceMhCIDandV1CIDPieceCommitmentConverters(t *testing.T) {
+	randBytes := make([]byte, 33)
+	_, err := rand.Read(randBytes)
+	require.NoError(t, err)
+	// Height must be at least 7
+	randBytes[0] = (randBytes[0] % (255 - 7)) + 7
+
+	mhv1 := testMultiHash(multihash.SHA2_256_TRUNC254_PADDED, randBytes[1:], 0)
+	cidv1 := cid.NewCidV1(cid.FilCommitmentUnsealed, mhv1)
+
+	mhv2 := testMultiHash(commcid.FR32_SHA256_TRUNC254_PADDED_BINARY_TREE_CODE, randBytes, 0)
+	cidv2 := cid.NewCidV1(cid.Raw, mhv2)
+
+	t.Run("convert v1 piece cid + height to piece mh cid", func(t *testing.T) {
+		c, err := commcid.ConvertDataCommitmentV1V1CIDtoPieceMhCID(cidv1, randBytes[0])
+		require.NoError(t, err)
+		require.True(t, c.Equals(cidv2))
+	})
+
+	t.Run("convert piece mh cid to v1 piece cid + height", func(t *testing.T) {
+		c, height, err := commcid.ConvertDataCommitmentV1PieceMhCIDToV1CID(cidv2)
+		require.NoError(t, err)
+		require.True(t, c.Equals(cidv1))
+		require.Equal(t, randBytes[0], height)
+	})
+
+	// Add test fixtures
+	tests := map[string]struct {
+		v1CidStr string
+		height   uint8
+		v2CidStr string
+	}{
+		"127OfEach0-1-2-3": {"baga6ea4seaqes3nobte6ezpp4wqan2age2s5yxcatzotcvobhgcmv5wi2xh5mbi", commcid.UnpaddedSizeToV1TreeHeight(127 * 4), "bafkzcibbarew3lqmzhrgl37fuadoqbrguxofyqe6luyvlqjzqtfpnsgvz7lak"},
+		"empty32GiB":       {"baga6ea4seaqao7s73y24kcutaosvacpdjgfe5pw76ooefnyqw4ynr3d2y6x2mpq", commcid.Fr32PaddedSizeToV1TreeHeight(32 << 30), "bafkzcibbdydx4x66gxcqveyduviaty2jrjhl5x7ttrbloefxgdmoy6whv6td4"},
+		"empty64GiB":       {"baga6ea4seaqomqafu276g53zko4k23xzh4h4uecjwicbmvhsuqi7o4bhthhm4aq", commcid.Fr32PaddedSizeToV1TreeHeight(64 << 30), "bafkzcibbd7teabngx7rxo6ktxcww56j7b7fbasnsaqlfj4vech3xaj4zz3hae"},
+	}
+
+	for name, tc := range tests {
+		t.Run(fmt.Sprintf("%s-v1-to-v2", name), func(t *testing.T) {
+			v1Cid, err := cid.Parse(tc.v1CidStr)
+			require.NoError(t, err)
+
+			v2Cid, err := cid.Parse(tc.v2CidStr)
+			require.NoError(t, err)
+
+			computedV2Cid, err := commcid.ConvertDataCommitmentV1V1CIDtoPieceMhCID(v1Cid, tc.height)
+			require.NoError(t, err)
+
+			require.True(t, v2Cid.Equals(computedV2Cid))
+		})
+
+		t.Run(fmt.Sprintf("%s-v2-to-v1", name), func(t *testing.T) {
+			v1Cid, err := cid.Parse(tc.v1CidStr)
+			require.NoError(t, err)
+
+			v2Cid, err := cid.Parse(tc.v2CidStr)
+			require.NoError(t, err)
+
+			computedV1Cid, computedHeight, err := commcid.ConvertDataCommitmentV1PieceMhCIDToV1CID(v2Cid)
+			require.NoError(t, err)
+
+			require.True(t, v1Cid.Equals(computedV1Cid))
+			require.Equal(t, tc.height, computedHeight)
+		})
+	}
 }
 
 func testMultiHash(code uint64, buf []byte, extra int) multihash.Multihash {

--- a/go.sum
+++ b/go.sum
@@ -15,7 +15,6 @@ github.com/multiformats/go-base36 v0.1.0 h1:JR6TyF7JjGd3m6FbLU2cOxhC0Li8z8dLNGQ8
 github.com/multiformats/go-base36 v0.1.0/go.mod h1:kFGE83c6s80PklsHO9sRn2NCoffoRdUUOENyW/Vv6sM=
 github.com/multiformats/go-multibase v0.0.3 h1:l/B6bJDQjvQ5G52jw4QGSYeOTZoAwIO77RblWplfIqk=
 github.com/multiformats/go-multibase v0.0.3/go.mod h1:5+1R4eQrT3PkYZ24C3W2Ue2tPwIdYQD509ZjSb5y9Oc=
-github.com/multiformats/go-multihash v0.0.13 h1:06x+mk/zj1FoMsgNejLpy6QTvJqlSt/BhLEy87zidlc=
 github.com/multiformats/go-multihash v0.0.13/go.mod h1:VdAWLKTwram9oKAatUcLxBNUjdtcVwxObEQBtRfuyjc=
 github.com/multiformats/go-multihash v0.0.14 h1:QoBceQYQQtNUuf6s7wHxnE2c8bhbMqhfGzNI032se/I=
 github.com/multiformats/go-multihash v0.0.14/go.mod h1:VdAWLKTwram9oKAatUcLxBNUjdtcVwxObEQBtRfuyjc=


### PR DESCRIPTION
This is a PR for adding support for a new type of piece CID based on treating the piece like a single large block similar to Blake3 (another tree hash used in the IPFS ecosystem).

See the [FRC](https://github.com/filecoin-project/FIPs/pull/758) for more details and discussion. This PR probably should not get merged until the FRC is merged.

Note: I switched to GitHub actions (copying the approach from https://github.com/protocol/.github) since my understanding was more projects are moving that way and I wanted to be able to test without relying on CircleCI, happy to remove this though. Can also register this project with https://github.com/protocol/.github for auto-updating of CI configs if that's desired.

cc @ribasushi @Kubuxu